### PR TITLE
chore: add eslint react hooks plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import neostandard from 'neostandard'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'coverage']),
   ...neostandard({ env: ['browser'] }),
   { extends: [reactHooks.configs['recommended-latest']] },
 ])

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,9 @@
+import { defineConfig, globalIgnores } from 'eslint/config'
+import reactHooks from 'eslint-plugin-react-hooks'
 import neostandard from 'neostandard'
 
-export default [
-  { ignores: ['dist/*', 'coverage/*'] },
+export default defineConfig([
+  globalIgnores(['dist']),
   ...neostandard({ env: ['browser'] }),
-]
+  { extends: [reactHooks.configs['recommended-latest']] }
+])

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,5 +5,5 @@ import neostandard from 'neostandard'
 export default defineConfig([
   globalIgnores(['dist']),
   ...neostandard({ env: ['browser'] }),
-  { extends: [reactHooks.configs['recommended-latest']] }
+  { extends: [reactHooks.configs['recommended-latest']] },
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@vitest/coverage-v8": "*",
         "conventional-changelog-conventionalcommits": "*",
         "eslint": "*",
+        "eslint-plugin-react-hooks": "*",
         "jsdom": "*",
         "neostandard": "*",
         "semantic-release": "*",
@@ -851,13 +852,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -865,9 +866,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3983,9 +3984,9 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.5.0.tgz",
-      "integrity": "sha512-/7gw8TGrvH/0g564EnhgFZogTMVe+lifpB7LWU+PEsiq5o83TUXR3fDbzTRXOJhoJwck5IS9ez3Em5LNMMO2aw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4962,9 +4963,9 @@
       }
     },
     "node_modules/eslint-plugin-import-x": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.15.2.tgz",
-      "integrity": "sha512-J5gx7sN6DTm0LRT//eP3rVVQ2Yi4hrX0B+DbWxa5er8PZ6JjLo9GUBwogIFvEDdwJaSqZplpQT+haK/cXhb7VQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.0.tgz",
+      "integrity": "sha512-g67gvUrgE1VeZ9lFoFM6RfYSh+R3kkxbxDMvNTsz+jxRmj5NA7SHCzhO5O+hDCnSTlLnITMFcl9/hXWudMvX7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5131,6 +5132,19 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
@@ -10904,9 +10918,9 @@
       "license": "MIT"
     },
     "node_modules/pathval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@vitest/coverage-v8": "*",
     "conventional-changelog-conventionalcommits": "*",
     "eslint": "*",
+    "eslint-plugin-react-hooks": "*",
     "jsdom": "*",
     "neostandard": "*",
     "semantic-release": "*",


### PR DESCRIPTION
When I `npm create`d a new react app I noticed that this plugin has been made eslint-9 compatible. It also catches a really minor possible bug that I introduced to the schedule hook.

Putting this up now but should probably come after the fix for that hook.

