### PR TITLE
chore: attempt to switch to oidc publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,12 @@
 name: deploy
-permissions:
-  id-token: write
 on:
   workflow_dispatch:
 jobs:
   release:
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - id: generate-token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: deploy
+permissions:
+  id-token: write
 on:
   workflow_dispatch:
 jobs:
@@ -22,5 +24,4 @@ jobs:
       - run: npx vite build
       - env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm run release
+        run: npx semantic-release

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
       "devDependencies": {
         "@semantic-release/changelog": "*",
         "@semantic-release/git": "*",
-        "@semantic-release/npm": "*",
         "@testing-library/react": "*",
         "@vitest/coverage-v8": "*",
         "conventional-changelog-conventionalcommits": "*",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "@semantic-release/changelog": "*",
     "@semantic-release/git": "*",
-    "@semantic-release/npm": "*",
     "@testing-library/react": "*",
     "@vitest/coverage-v8": "*",
     "conventional-changelog-conventionalcommits": "*",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint",
-    "release": "semantic-release",
     "test": "vitest run"
   },
   "dependencies": {

--- a/release.config.js
+++ b/release.config.js
@@ -9,7 +9,6 @@ export default {
       "@semantic-release/git",
       {
         assets: ["package.json", "package-lock.json", "CHANGELOG.md"],
-        // eslint-disable-next-line no-template-curly-in-string
         message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
       },
     ],


### PR DESCRIPTION
Which should hopefully fix the release process. I told npm that this workflow is to be trusted... and saw no further documentation from semantic release so this _might_ be all that's needed?:x

