### PR TITLE
Explicitly set chore prefix for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: chore(deps)
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -22,3 +24,5 @@ updates:
           - "vitest*"
           - "@vitest/*"
           - "@testing-library/*"
+    commit-message:
+      prefix: chore(deps)


### PR DESCRIPTION
#139 and #138 accidentally went through with the `fix` prefix which would trigger a patch release (which it shouldnt as these are true dev dependencies).

Dependabot set it because I happened to manually merge #137 (now a _bundled_ dependency, therefore needing a patch) a couple days ago and I guess it remembers the last prefix that you used.

I looked a while ago and I can't set different defaults for differen packages, so I think this is the best/least destructive way to have things set up.

i.e. it's easier to fix an erroenous `chore` (can add another commit to trigger the patch) than an erroenous `fix` (have to reword/force push to main, which I've done for this case).

